### PR TITLE
Compatibility with JupyterHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # igv Jupyter Extension
 
+[![Binder](https://beta.mybinder.org/badge.svg)](https://mybinder.org/v2/gh/tmtabor/igv-jupyter/master?filepath=examples/BamFiles.ipynb)
+
 IGV is an extension for [Jupyter Notebook](http://jupyter.org/) which
 wraps [igv.js](https://github.com/igvteam/igv.js).  With this
 extension you can render igv.js in a cell and call its API from

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # igv Jupyter Extension
 
-[![Binder](https://beta.mybinder.org/badge.svg)](https://mybinder.org/v2/gh/tmtabor/igv-jupyter/master?filepath=examples/BamFiles.ipynb)
+[![Binder](https://beta.mybinder.org/badge.svg)](https://mybinder.org/v2/gh/igvteam/igv-jupyter/master?filepath=examples/BamFiles.ipynb)
 
 IGV is an extension for [Jupyter Notebook](http://jupyter.org/) which
 wraps [igv.js](https://github.com/igvteam/igv.js).  With this

--- a/igv/static/extension.js
+++ b/igv/static/extension.js
@@ -1,5 +1,5 @@
 define(
-    ["/nbextensions/igv/igvjs/igv.js"],
+    ["nbextensions/igv/igvjs/igv"],
     //["https://cdn.jsdelivr.net/npm/igv@2.1.0/dist/igv.min.js"],
     function (igv) {
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,4 @@
+pip install -e igv
+jupyter serverextension enable igv
+jupyter nbextension install --py igv
+jupyter nbextension enable --py igv

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
 pip install .
-jupyter serverextension enable igv
-jupyter nbextension install --py igv
-jupyter nbextension enable --py igv
+jupyter serverextension enable igv --sys-prefix
+jupyter nbextension install --py igv --sys-prefix
+jupyter nbextension enable --py igv --sys-prefix

--- a/postBuild
+++ b/postBuild
@@ -1,4 +1,4 @@
-pip install -e igv
+pip install .
 jupyter serverextension enable igv
 jupyter nbextension install --py igv
 jupyter nbextension enable --py igv


### PR DESCRIPTION
The only necessary change is the one line in extension.js. I removed the proceeding slash and .js on the require.js import. Without the slash, you trust that Jupyter's require.js configuration knows where to find the extension.

I also added a postBuild file and MyBinder button for easily testing and demoing the extension. If you don't want those, let me know and I will remove them from the pull request.