### PR TITLE
Update command-line flags for labextension enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jupyter nbextension enable --py igv
 
 # If using a virtual environment
 jupyter serverextension enable --py igv --sys-prefix
-jupyter labextension enable igv --sys-prefix
+jupyter labextension enable igv --level sys_prefix
 jupyter nbextension install --py igv --sys-prefix
 jupyter nbextension enable --py igv --sys-prefix
 


### PR DESCRIPTION
Hello!

It appears the command-line flags of `jupyer labextension` have changed to use `--level` (https://github.com/jupyterlab/jupyterlab/commit/617c3ac94aee0e017cb0ce22ae5bbffd7f264bd1) instead of `--sys-prefix`. I've updated the installation instructions to reflect this.